### PR TITLE
Change the commit diff descriptions to match with how it actually works

### DIFF
--- a/src/main/resources/static/simple.soy
+++ b/src/main/resources/static/simple.soy
@@ -205,7 +205,7 @@
             {param id: 'checkCommitDiffRegexp' /}
             {param labelContent: 'Check commit diff' /}
             {param value: $config['checkCommitDiffRegexp'] /}
-            {param descriptionText: 'Reject the commit if its diff does not match the regular expression, leave empty to check all.' /}
+            {param descriptionText: 'Reject the commit if its diff matches the regular expression, leave empty to disable check.' /}
             {param errorTexts: $errors ? $errors['checkCommitDiffRegexp'] : null /}
         {/call}
 
@@ -214,7 +214,7 @@
             {param labelContent: 'Reject message' /}
             {param value: $config['checkCommitDiffRegexpMessage'] /}
             {param rows: 3 /}
-            {param descriptionText: 'Reject message to show if commit diff not matching regular expression.' /}
+            {param descriptionText: 'Reject message to show if commit diff matches regular expression.' /}
             {param errorTexts: $errors ? $errors['checkCommitDiffRegexpMessage'] : null /}
         {/call}
     </div>


### PR DESCRIPTION
I was happy to find this plugin, allowing us to disable push of some potentially harmful changes into our repository. However, the descriptions for the commit diff check initially confused me as my testing indicates it works exactly the other way around. I've updated them to reflect that; do let me know if I'm missing something here!