### PR TITLE
Fix for issue #96 (breakage thanks to "--not" and Bitbucket 6.5.x)

### DIFF
--- a/src/main/java/se/bjurr/sbcc/commits/ChangeSetsService.java
+++ b/src/main/java/se/bjurr/sbcc/commits/ChangeSetsService.java
@@ -85,12 +85,14 @@ public class ChangeSetsService {
       final String toHash,
       final Optional<GitScmCommandBuilder> gitScmCommandBuilder,
       final SbccSettings settings) {
-    final GitRevListBuilder revListBuilder =
+    final GitScmCommandBuilder revListBuilder =
         gitScmCommandBuilder
             .get() //
-            .revList() //
-            .format(FORMAT) //
-            .revs(toHash, "--not", "--all");
+            .command("rev-list") //
+            .argument("--pretty=" + FORMAT) //
+            .argument(toHash) //
+            .argument("--not") //
+            .argument("--all");
 
     final List<SbccChangeSet> found =
         revListBuilder //


### PR DESCRIPTION
This should fix issue #96 (Bitbucket 6.5.x no longer accepts "--not" as a revList() reference).

I haven't tested it, but I'm pretty sure this fixes it.